### PR TITLE
Add anonymous lifetime annotation to Cow<str> return types

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -8,7 +8,7 @@ use crate::percent_encoding::percent_decode_str;
 
 /// Decode percent-encoded bytes in a given string.
 #[inline]
-pub fn decode<S: ?Sized + AsRef<str>>(text: &S) -> Cow<str> {
+pub fn decode<S: ?Sized + AsRef<str>>(text: &S) -> Cow<'_, str> {
     let pd = percent_decode_str(text.as_ref());
 
     pd.decode_utf8_lossy()

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -109,7 +109,7 @@ macro_rules! encode_impl {
         ///
         $(#[$attr])*
         #[inline]
-        pub fn $encode_name<S: ?Sized + AsRef<str>>(text: &S) -> Cow<str> {
+        pub fn $encode_name<S: ?Sized + AsRef<str>>(text: &S) -> Cow<'_,str> {
             encode(text, $escape_set)
         }
 


### PR DESCRIPTION
This PR fixes a warning thrown up by the `mismatched_lifetime_syntaxes` lint in Rust 1.89.

It doesn't change the code substantially, and up to you whether you think this is more clear/readable.